### PR TITLE
Add `executionEnabled` schema attribute to rundeck job

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -31,6 +31,7 @@ type JobDetail struct {
 	ProjectName               string              `xml:"context>project,omitempty"`
 	OptionsConfig             *JobOptions         `xml:"context>options,omitempty"`
 	Description               string              `xml:"description,omitempty"`
+	ExecutionEnabled          bool                `xml:"executionEnabled,omitempty"`
 	LogLevel                  string              `xml:"loglevel,omitempty"`
 	AllowConcurrentExecutions bool                `xml:"multipleExecutions"`
 	Dispatch                  *JobDispatch        `xml:"dispatch"`


### PR DESCRIPTION
I'm looking to contribute to Terraform's Rundeck provider. I started with [this](https://github.com/hashicorp/terraform/pull/4122) pull request. I figured I'll need to contribute here as well. I haven't tested this change and I would appreciate some feedback on that.
