### PR TITLE
add boolean NodesSelectedByDefault for jobdetails

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -36,6 +36,7 @@ type JobDetail struct {
 	Dispatch                  *JobDispatch        `xml:"dispatch"`
 	CommandSequence           *JobCommandSequence `xml:"sequence,omitempty"`
 	NodeFilter                *JobNodeFilter      `xml:"nodefilters,omitempty"`
+	NodesSelectedByDefault    bool                `xml:"nodesSelectedByDefault,omitempty"`
 }
 
 type jobDetailList struct {


### PR DESCRIPTION
I would like to have nodesSelectedByDefault added to the go-rundeck-api.
I am currently working on the terraform/rundeck provider, that will come after.
