### PR TITLE
Add a JobCommand ScriptInterpreter with matching tests.

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -128,11 +128,17 @@ type JobCommand struct {
 	// a shell script it should have an appropriate #! line.
 	Script string `xml:"script,omitempty"`
 
+	// Add extension to the temporary filename.
+	FileExtension string `xml:"fileExtension,omitempty"`
+
 	// A pre-existing file (on the target nodes) that will be executed.
 	ScriptFile string `xml:"scriptfile,omitempty"`
 
 	// When ScriptFile is set, the arguments to provide to the script when executing it.
 	ScriptFileArgs string `xml:"scriptargs,omitempty"`
+
+	// ScriptInterpreter is used to execute (Script)File with.
+	ScriptInterpreter *JobCommandScriptInterpreter `xml:"scriptinterpreter,omitempty"`
 
 	// A reference to another job to run as this command.
 	Job *JobCommandJobRef `xml:"jobref"`
@@ -142,6 +148,13 @@ type JobCommand struct {
 
 	// Configuration for a node step plugin to run as this command.
 	NodeStepPlugin *JobPlugin `xml:"node-step-plugin"`
+}
+
+// (Inline) Script interpreter
+type JobCommandScriptInterpreter struct {
+	XMLName          xml.Name `xml:"scriptinterpreter"`
+	InvocationString string   `xml:",chardata"`
+	ArgsQuoted       bool     `xml:"argsquoted,attr,omitempty"`
 }
 
 // JobCommandJobRef is a reference to another job that will run as one of the commands of a job.

--- a/rundeck/job_test.go
+++ b/rundeck/job_test.go
@@ -111,3 +111,138 @@ func TestUnmarshalJobPlugin(t *testing.T) {
 		},
 	})
 }
+
+func TestMarshalJobCommand(t *testing.T) {
+	testMarshalXML(t, []marshalTest{
+		marshalTest{
+			"with-shell",
+			JobCommand{
+				ShellCommand: "command",
+			},
+			`<JobCommand><exec>command</exec></JobCommand>`,
+		},
+		marshalTest{
+			"with-script",
+			JobCommand{
+				Script: "script",
+			},
+			`<JobCommand><script>script</script></JobCommand>`,
+		},
+		marshalTest{
+			"with-script-interpreter",
+			JobCommand{
+				FileExtension: "sh",
+				Script: "Hello World!",
+			  ScriptInterpreter: &JobCommandScriptInterpreter{
+						InvocationString: "sudo",
+				},
+			},
+			`<JobCommand><script>Hello World!</script><fileExtension>sh</fileExtension><scriptinterpreter>sudo</scriptinterpreter></JobCommand>`,
+		},
+	})
+}
+
+func TestUnmarshalJobCommand(t *testing.T) {
+	testUnmarshalXML(t, []unmarshalTest{
+		unmarshalTest{
+			"with-shell",
+			`<JobCommand><exec>command</exec></JobCommand>`,
+			&JobCommand{},
+			func (rv interface {}) error {
+				v := rv.(*JobCommand)
+				if v.ShellCommand != "command" {
+					return fmt.Errorf("got ShellCommand %s, but expecting command", v.ShellCommand)
+				}
+				return nil
+			},
+		},
+		unmarshalTest{
+			"with-script",
+			`<JobCommand><script>script</script></JobCommand>`,
+			&JobCommand{},
+			func (rv interface {}) error {
+				v := rv.(*JobCommand)
+				if v.Script != "script" {
+					return fmt.Errorf("got Script %s, but expecting script", v.Script)
+				}
+				return nil
+			},
+		},
+		unmarshalTest{
+			"with-script-interpreter",
+			`<JobCommand><script>Hello World!</script><fileExtension>sh</fileExtension><scriptinterpreter>sudo</scriptinterpreter></JobCommand>`,
+			&JobCommand{},
+			func (rv interface {}) error {
+				v := rv.(*JobCommand)
+				if v.FileExtension != "sh" {
+					return fmt.Errorf("got FileExtension %s, but expecting sh", v.FileExtension)
+				}
+				if v.Script != "Hello World!" {
+					return fmt.Errorf("got Script %s, but expecting Hello World!", v.Script)
+				}
+				if v.ScriptInterpreter == nil {
+					return fmt.Errorf("got %s, but expecting not nil", v.ScriptInterpreter)
+				}
+				if v.ScriptInterpreter.InvocationString != "sudo" {
+					return fmt.Errorf("got InvocationString %s, but expecting sudo", v.ScriptInterpreter.InvocationString)
+				}
+				return nil
+			},
+		},
+	})
+}
+
+func TestMarshalScriptInterpreter(t *testing.T) {
+	testMarshalXML(t, []marshalTest{
+		marshalTest{
+			"with-script-interpreter",
+			JobCommandScriptInterpreter{
+					InvocationString: "sudo",
+			},
+			`<scriptinterpreter>sudo</scriptinterpreter>`,
+		},
+		marshalTest{
+			"with-script-interpreter-quoted",
+			JobCommandScriptInterpreter{
+					ArgsQuoted: true,
+					InvocationString: "sudo",
+			},
+			`<scriptinterpreter argsquoted="true">sudo</scriptinterpreter>`,
+		},
+	})
+}
+
+func TestUnmarshalScriptInterpreter(t *testing.T) {
+	testUnmarshalXML(t, []unmarshalTest{
+		unmarshalTest{
+			"with-script-interpreter",
+			`<scriptinterpreter>sudo</scriptinterpreter>`,
+			&JobCommandScriptInterpreter{},
+			func (rv interface {}) error {
+				v := rv.(*JobCommandScriptInterpreter)
+				if v.InvocationString != "sudo" {
+					return fmt.Errorf("got InvocationString %s, but expecting sudo", v.InvocationString)
+				}
+				if v.ArgsQuoted {
+					return fmt.Errorf("got ArgsQuoted %s, but expecting false", v.ArgsQuoted)
+				}
+				return nil
+			},
+		},
+		unmarshalTest{
+			"with-script-interpreter-quoted",
+			`<scriptinterpreter argsquoted="true">sudo</scriptinterpreter>`,
+			&JobCommandScriptInterpreter{},
+			func (rv interface {}) error {
+				v := rv.(*JobCommandScriptInterpreter)
+				if v.InvocationString != "sudo" {
+					return fmt.Errorf("got InvocationString %s, but expecting sudo", v.InvocationString)
+				}
+				if ! v.ArgsQuoted {
+					return fmt.Errorf("got ArgsQuoted %s, but expecting true", v.ArgsQuoted)
+				}
+				return nil
+			},
+		},
+	})
+}


### PR DESCRIPTION
Another update:
Version Rundeck: 2.6.7-1

For scripts and script files you can enter a script interpreter with an invocation string and optionally 'argsquoted'.
Also you can choose a file extension, so i threw that one in as well :smile: 

Because i had a little bit more trouble with this one, i also wrote some tests.
Just to make shure the xml output is correct.

Without:

``` xml
<joblist>
  <job>
    ...
    <sequence keepgoing='false' strategy='node-first'>
      <command>
        <script><![CDATA[script]]></script>
        <scriptargs />
      </command>
    </sequence>
    ...
  </job>
</joblist>
```

With:

``` xml
<joblist>
  <job>
    ...
    <sequence keepgoing='false' strategy='node-first'>
      <command>
        <fileExtension>sh</fileExtension>
        <script><![CDATA[script]]></script>
        <scriptargs />
        <scriptinterpreter argsquoted='true'>sudo</scriptinterpreter>
      </command>
    </sequence>
    ...
  </job>
</joblist>
```
