### PR TITLE
Add description for a command.

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -121,6 +121,9 @@ type JobCommandSequence struct {
 type JobCommand struct {
 	XMLName xml.Name
 
+	// Description
+	Description string `xml:"description,omitempty"`
+
 	// A literal shell command to run.
 	ShellCommand string `xml:"exec,omitempty"`
 


### PR DESCRIPTION
Extra command description, is handy if the gui is used by other people.
This way extra descriptions for each command can be given.
