### PR TITLE
Bug: renamed schema object delimeter to delimiter

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -96,39 +96,26 @@ type JobOptions struct {
 type JobOption struct {
 	XMLName xml.Name `xml:"option"`
 
-	// The name of the option, which can be used to interpolate its value
-	// into job commands.
-	Name string `xml:"name,attr,omitempty"`
-
-	// The default value of the option.
-	DefaultValue string `xml:"value,attr,omitempty"`
-
-	// A sequence of predefined choices for this option. Mutually exclusive with ValueChoicesURL.
-	ValueChoices JobValueChoices `xml:"values,attr"`
-
-	// A URL from which the predefined choices for this option will be retrieved.
-	// Mutually exclusive with ValueChoices
-	ValueChoicesURL string `xml:"valuesUrl,attr,omitempty"`
+	// If AllowsMultipleChoices is set, the string that will be used to delimit the multiple
+	// chosen options.
+	MultiValueDelimiter string `xml:"delimiter,attr,omitempty"`
 
 	// If set, Rundeck will reject values that are not in the set of predefined choices.
 	RequirePredefinedChoice bool `xml:"enforcedvalues,attr,omitempty"`
-
-	// Regular expression to be used to validate the option value.
-	ValidationRegex string `xml:"regex,attr,omitempty"`
-
-	// Description of the value to be shown in the Rundeck UI.
-	Description string `xml:"description,omitempty"`
-
-	// If set, Rundeck requires a value to be set for this option.
-	IsRequired bool `xml:"required,attr,omitempty"`
 
 	// When either ValueChoices or ValueChoicesURL is set, controls whether more than one
 	// choice may be selected as the value.
 	AllowsMultipleValues bool `xml:"multivalued,attr,omitempty"`
 
-	// If AllowsMultipleChoices is set, the string that will be used to delimit the multiple
-	// chosen options.
-	MultiValueDelimiter string `xml:"delimeter,attr,omitempty"`
+	// The name of the option, which can be used to interpolate its value
+	// into job commands.
+	Name string `xml:"name,attr,omitempty"`
+
+	// Regular expression to be used to validate the option value.
+	ValidationRegex string `xml:"regex,attr,omitempty"`
+
+	// If set, Rundeck requires a value to be set for this option.
+	IsRequired bool `xml:"required,attr,omitempty"`
 
 	// If set, the input for this field will be obscured in the UI. Useful for passwords
 	// and other secrets.
@@ -137,9 +124,23 @@ type JobOption struct {
 	// If ObscureInput is set, StoragePath can be used to point out credentials.
 	StoragePath string `xml:"storagePath,attr,omitempty"`
 
+	// The default value of the option.
+	DefaultValue string `xml:"value,attr,omitempty"`
+
 	// If set, the value can be accessed from scripts.
 	ValueIsExposedToScripts bool `xml:"valueExposed,attr,omitempty"`
+
+	// A sequence of predefined choices for this option. Mutually exclusive with ValueChoicesURL.
+	ValueChoices JobValueChoices `xml:"values,attr"`
+
+	// A URL from which the predefined choices for this option will be retrieved.
+	// Mutually exclusive with ValueChoices
+	ValueChoicesURL string `xml:"valuesUrl,attr,omitempty"`
+
+	// Description of the value to be shown in the Rundeck UI.
+	Description string `xml:"description,omitempty"`
 }
+
 
 // JobValueChoices is a specialization of []string representing a sequence of predefined values
 // for a job option.

--- a/rundeck/job_test.go
+++ b/rundeck/job_test.go
@@ -246,3 +246,45 @@ func TestUnmarshalScriptInterpreter(t *testing.T) {
 		},
 	})
 }
+
+func TestMarshalJobOption(t *testing.T) {
+	testMarshalXML(t, []marshalTest{
+		marshalTest{
+			"with-option-basic",
+			JobOption{
+				Name: "basic",
+			},
+			`<option name="basic"></option>`,
+		},
+		marshalTest{
+			"with-option-multivalued",
+			JobOption{
+				Name: "Multivalued",
+				MultiValueDelimiter: "|",
+				RequirePredefinedChoice: true,
+				AllowsMultipleValues: true,
+				IsRequired: true,
+				ValueChoices: JobValueChoices([]string{"myValues"}),
+			},
+			`<option delimiter="|" enforcedvalues="true" multivalued="true" name="Multivalued" required="true" values="myValues"></option>`,
+		},
+		marshalTest{
+			"with-all-attributes",
+			JobOption{
+				Name: "advanced",
+				MultiValueDelimiter: "|",
+				RequirePredefinedChoice: true,
+				AllowsMultipleValues: true,
+				ValidationRegex: ".+",
+				IsRequired: true,
+				ObscureInput: true,
+				StoragePath: "myKey",
+				DefaultValue: "myValue",
+				ValueIsExposedToScripts: true,
+				ValueChoices: JobValueChoices([]string{"myValues"}),
+				ValueChoicesURL: "myValuesUrl",
+			},
+			`<option delimiter="|" enforcedvalues="true" multivalued="true" name="advanced" regex=".+" required="true" secure="true" storagePath="myKey" value="myValue" valueExposed="true" values="myValues" valuesUrl="myValuesUrl"></option>`,
+		},
+	})
+}


### PR DESCRIPTION
@apparentlymart Sorry, but i introduced a bug.

I was getting an error: 

> Invalid Option definition: Environment: You must specify a delimiter for multivalued options

After that i noticed that i made a small typo and also added a test for this, so this does not happen again.

With that i ordered the attributes in the correct order Rundeck is supplying, this makes copying the job output xml easier for the test.
