### PR TITLE
added a recursive jobcommand reference for errorhandling

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -172,18 +172,24 @@ type JobCommandSequence struct {
 type JobCommand struct {
 	XMLName xml.Name
 
+	// If the Workflow keepgoing is false, this allows the Workflow to continue when the Error Handler is successful.
+	ContinueOnError bool     `xml:"keepgoingOnSuccess,attr,omitempty"`
+
 	// Description
 	Description string `xml:"description,omitempty"`
+
+	// On error:
+	ErrorHandler *JobCommand `xml:"errorhandler,omitempty"`
 
 	// A literal shell command to run.
 	ShellCommand string `xml:"exec,omitempty"`
 
+	// Add extension to the temporary filename.
+	FileExtension string `xml:"fileExtension,omitempty"`
+
 	// An inline program to run. This will be written to disk and executed, so if it is
 	// a shell script it should have an appropriate #! line.
 	Script string `xml:"script,omitempty"`
-
-	// Add extension to the temporary filename.
-	FileExtension string `xml:"fileExtension,omitempty"`
 
 	// A pre-existing file (on the target nodes) that will be executed.
 	ScriptFile string `xml:"scriptfile,omitempty"`

--- a/rundeck/job_test.go
+++ b/rundeck/job_test.go
@@ -137,7 +137,7 @@ func TestMarshalJobCommand(t *testing.T) {
 						InvocationString: "sudo",
 				},
 			},
-			`<JobCommand><script>Hello World!</script><fileExtension>sh</fileExtension><scriptinterpreter>sudo</scriptinterpreter></JobCommand>`,
+			`<JobCommand><fileExtension>sh</fileExtension><script>Hello World!</script><scriptinterpreter>sudo</scriptinterpreter></JobCommand>`,
 		},
 	})
 }
@@ -247,6 +247,29 @@ func TestUnmarshalScriptInterpreter(t *testing.T) {
 	})
 }
 
+func TestMarshalErrorHanlder(t *testing.T) {
+	testMarshalXML(t, []marshalTest{
+		marshalTest{
+			"with-errorhandler",
+			JobCommandSequence{
+				ContinueOnError: true,
+				OrderingStrategy: "step-first",
+				Commands: []JobCommand{
+					JobCommand{
+						Script: "inline_script",
+						ErrorHandler: &JobCommand{
+							ContinueOnError: true,
+							Script: "error_script",
+						},
+					},
+				},
+			},
+			`<sequence keepgoing="true" strategy="step-first"><command><errorhandler keepgoingOnSuccess="true"><script>error_script</script></errorhandler><script>inline_script</script></command></sequence>`,
+		},
+	})
+}
+
+
 func TestMarshalJobOption(t *testing.T) {
 	testMarshalXML(t, []marshalTest{
 		marshalTest{
@@ -288,3 +311,4 @@ func TestMarshalJobOption(t *testing.T) {
 		},
 	})
 }
+


### PR DESCRIPTION
``` xml
<joblist>
  <job>
    ...
    <sequence keepgoing='true' strategy='step-first'>
      <command>
        <description>description</description>
        <errorhandler keepgoingOnSuccess='true'> <!-- This is a job with an extra atribute. -->
          <fileExtension>sh2</fileExtension>
          <script><![CDATA[error]]></script>
          <scriptargs>args2</scriptargs>
          <scriptinterpreter argsquoted='true'>sudo</scriptinterpreter>
        </errorhandler>
        <fileExtension>sh</fileExtension>
        <script><![CDATA[script]]></script>
        <scriptargs>args</scriptargs>
        <scriptinterpreter argsquoted='true'>sudo</scriptinterpreter>
      </command>
    </sequence>
    ...
  </job>
</joblist>
```
