### PR TITLE
added dispatch for jobref, this will enable overwriting dispatch values

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -223,6 +223,7 @@ type JobCommandJobRef struct {
 	Name           string                    `xml:"name,attr"`
 	GroupName      string                    `xml:"group,attr"`
 	RunForEachNode bool                      `xml:"nodeStep,attr"`
+	Dispatch       *JobDispatch              `xml:"dispatch,omitempty"`
 	NodeFilter     *JobNodeFilter            `xml:"nodefilters,omitempty"`
 	Arguments      JobCommandJobRefArguments `xml:"arg"`
 }


### PR DESCRIPTION
Example xml:

``` xml
<joblist><job>
    ...
    <sequence keepgoing='false' strategy='node-first'>
      <command>
        <jobref group='group' name='jobname'>
          <dispatch>
            <keepgoing>true</keepgoing>
            <rankOrder>ascending</rankOrder>
            <threadcount>1</threadcount>
          </dispatch>
          ...
        </jobref>
      </command>
    </sequence>
  </job>
</joblist>
```

This will introduce the same wrong handling of a boolen, but it is supported.
ContinueOnError(keepgoing) should have 3 state's:
- keepgoing = true
- keepgoing = false
- keepgoing = omitted, nil (not there, this wil leave it default or up to the job that is called.)

The current solution is as followed:

``` terraform
ContinueOnError bool   `xml:"keepgoing"`
```

When this is ommited this means that this value translates to a boolean false.
Witch would translate to overwrite keepgoing on a jobref.
The results wanted is dont do anything, just leave it to the job that is called.
