### PR TITLE
changed nodesselectedbydefault from bool to string

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -38,12 +38,7 @@ type JobDetail struct {
 	Timeout                   string              `xml:"timeout,omitempty"`
 	Retry                     string              `xml:"retry,omitempty"`
 	NodeFilter                *JobNodeFilter      `xml:"nodefilters,omitempty"`
-
-	/* If Dispatch is enabled, nodesSelectedByDefault is always present with true/false.
-	 * by this reason omitempty cannot be present.
-	 * This has to be handle by the user.
-	 */
-	NodesSelectedByDefault    bool                `xml:"nodesSelectedByDefault"`
+	NodesSelectedByDefault    string              `xml:"nodesSelectedByDefault,omitempty"`
 	Schedule                  *JobSchedule        `xml:"schedule"`
 }
 


### PR DESCRIPTION
...to support false/true/nil,ommitted

I tried to find a way to make a nill object out of a boolean, but i cant seem to find a way.
The only way is to make a reference to another object, that is a boolean, but this means that the code implementing this go-rundeck-api will have to make adjustment to its code. This is unwanted in my opinion. Like so.

``` go
type JobDetail struct {
    XMLName   xml.Name   `xml:"job"`
    NodesSelectedByDefault     *Boolean    `xml:"nodesSelectedByDefault"`
}
type Boolean bool
```

and the client implementing it would do something like this:

``` go
myValue := &Boolean(false)
```

The above is one solution, the other one that i seem to come across and dont think i can get around it is make it a string attribute. This way the nill or empty string value can be omitted. And after that the value can be set to "false" or "true". This means validation over this value has to be done. But the code is working then as it should be.

Look at the example below, witch shows that the omitted value can't be a boolen. Else the element should not be present.
- Defaultjob, the nodesSelectedByDefault is not present and is omitted.
- Dispatch to nodes, the element is present and contains a false value

Default job, with no element nodesSelectedByDefault present:

``` xml
<joblist>
  <job>
    <description></description>
    <executionEnabled>true</executionEnabled>
    <id>08d42f36-83da-4c66-90ba-5ff4c68a2f87</id>
    <loglevel>INFO</loglevel>
    <name>default</name>
    <scheduleEnabled>true</scheduleEnabled>
    <sequence keepgoing='false' strategy='node-first'>
      <command>
        <exec>echo hi</exec>
      </command>
    </sequence>
    <uuid>08d42f36-83da-4c66-90ba-5ff4c68a2f87</uuid>
  </job>
</joblist>
```
- Dispatch to nodes, the element is present and contains a false value

``` xml
<joblist>
  <job>
    <description></description>
    <dispatch>
      <excludePrecedence>true</excludePrecedence>
      <keepgoing>false</keepgoing>
      <rankOrder>ascending</rankOrder>
      <threadcount>1</threadcount>
    </dispatch>
    <executionEnabled>true</executionEnabled>
    <id>08d42f36-83da-4c66-90ba-5ff4c68a2f87</id>
    <loglevel>INFO</loglevel>
    <name>default</name>
    <nodefilters>
      <filter></filter>
    </nodefilters>
    <nodesSelectedByDefault>false</nodesSelectedByDefault>
    <scheduleEnabled>true</scheduleEnabled>
    <sequence keepgoing='false' strategy='node-first'>
      <command>
        <exec>echo hi</exec>
      </command>
    </sequence>
    <uuid>08d42f36-83da-4c66-90ba-5ff4c68a2f87</uuid>
  </job>
</joblist>
```

This pull will allow three values, but does not implement validation.
That has to be done by the one implementing this api.

Rundeck should fix this by moving nodesSelectedByDefault to the dispatch element, like this:

``` xml
<joblist>
  <job>
    <description></description>
    <dispatch>
      <nodesSelectedByDefault>false</nodesSelectedByDefault>
      <excludePrecedence>true</excludePrecedence>
      <keepgoing>false</keepgoing>
      <rankOrder>ascending</rankOrder>
      <threadcount>1</threadcount>
    </dispatch>
    <executionEnabled>true</executionEnabled>
    <id>08d42f36-83da-4c66-90ba-5ff4c68a2f87</id>
    <loglevel>INFO</loglevel>
    <name>default</name>
    <nodefilters>
      <filter></filter>
    </nodefilters>
    <scheduleEnabled>true</scheduleEnabled>
    <sequence keepgoing='false' strategy='node-first'>
      <command>
        <exec>echo hi</exec>
      </command>
    </sequence>
    <uuid>08d42f36-83da-4c66-90ba-5ff4c68a2f87</uuid>
  </job>
</joblist>
```
