### PR TITLE
Support keystore passwords

### DIFF
--- a/rundeck/key.go
+++ b/rundeck/key.go
@@ -61,6 +61,14 @@ func (c *Client) ReplacePrivateKey(path string, content string) error {
 	return c.createOrReplacePublicKey("PUT", path, "application/octet-stream", content)
 }
 
+func (c *Client) CreatePassword(path string, content string) error {
+	return c.createOrReplacePassword("POST", path, "x-rundeck-data-password", content)
+}
+
+func (c *Client) ReplacePassword(path string, content string) error {
+	return c.createOrReplacePassword("PUT", path, "x-rundeck-data-password", content)
+}
+
 func (c *Client) createOrReplacePublicKey(method string, path string, contentType string, content string) error {
 	req := &request{
 		Method: method,

--- a/rundeck/key.go
+++ b/rundeck/key.go
@@ -62,11 +62,11 @@ func (c *Client) ReplacePrivateKey(path string, content string) error {
 }
 
 func (c *Client) CreatePassword(path string, content string) error {
-	return c.createOrReplacePassword("POST", path, "application/x-rundeck-data-password", content)
+	return c.createOrReplacePublicKey("POST", path, "application/x-rundeck-data-password", content)
 }
 
 func (c *Client) ReplacePassword(path string, content string) error {
-	return c.createOrReplacePassword("PUT", path, "application/x-rundeck-data-password", content)
+	return c.createOrReplacePublicKey("PUT", path, "application/x-rundeck-data-password", content)
 }
 
 func (c *Client) createOrReplacePublicKey(method string, path string, contentType string, content string) error {

--- a/rundeck/key.go
+++ b/rundeck/key.go
@@ -62,11 +62,11 @@ func (c *Client) ReplacePrivateKey(path string, content string) error {
 }
 
 func (c *Client) CreatePassword(path string, content string) error {
-	return c.createOrReplacePassword("POST", path, "x-rundeck-data-password", content)
+	return c.createOrReplacePassword("POST", path, "application/x-rundeck-data-password", content)
 }
 
 func (c *Client) ReplacePassword(path string, content string) error {
-	return c.createOrReplacePassword("PUT", path, "x-rundeck-data-password", content)
+	return c.createOrReplacePassword("PUT", path, "application/x-rundeck-data-password", content)
 }
 
 func (c *Client) createOrReplacePublicKey(method string, path string, contentType string, content string) error {


### PR DESCRIPTION
I'd like to be able to add support for keystore passwords to the terraform rundeck provider, looks like the api needs to be updated to support it first.